### PR TITLE
fix: Sentry env

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -5,10 +5,14 @@
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+                           process.env.APP_ENV || process.env.NEXT_PUBLIC_APP_ENV ||
+                           process.env.NODE_ENV;
 
 if (process.env.NODE_ENV !== 'development') {
   Sentry.init({
     dsn: SENTRY_DSN ?? '',
+    environment: SENTRY_ENVIRONMENT,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,10 +6,14 @@
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+                           process.env.APP_ENV || process.env.NEXT_PUBLIC_APP_ENV ||
+                           process.env.NODE_ENV;
 
 if (process.env.NODE_ENV !== 'development') {
   Sentry.init({
     dsn: SENTRY_DSN ?? '',
+    environment: SENTRY_ENVIRONMENT,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,10 +5,14 @@
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+                           process.env.APP_ENV || process.env.NEXT_PUBLIC_APP_ENV ||
+                           process.env.NODE_ENV;
 
 if (process.env.NODE_ENV !== 'development') {
   Sentry.init({
     dsn: SENTRY_DSN ?? '',
+    environment: SENTRY_ENVIRONMENT,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,


### PR DESCRIPTION
pour différencier `production` de `staging` (recette) tout en restant en Node production pour les librairies.
via variable d'environnement `SENTRY_ENVIRONMENT` ou `NEXT_PUBLIC_SENTRY_ENVIRONMENT` ou `APP_ENV` ou `NEXT_PUBLIC_APP_ENV`