### PR TITLE
fix: buildpack

### DIFF
--- a/.builddpacks
+++ b/.builddpacks
@@ -1,0 +1,1 @@
+https://github.com/Scalingo/nodejs-buildpack.git


### PR DESCRIPTION
>  !     We didn't find the type of technology you are using...
We're sorry this build is failing!
Refer to the documentation to find out why:
https://doc.scalingo.com/platform/getting-started/common-deployment-errors#unknown-technology
