### PR TITLE
chore: refacto API & use NextJs Server Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Mon Devis Sans Oublis - Frontend
 
-Une application Next.js pour créer des devis sans oublier les éléments essentiels.
+Plateforme d'analyse de conformité de devis pour accélérer la rénovation énergétique des logements en simplifiant l'instruction des dossiers d'aide.
+
+🔗 **[Accéder à la plateforme](https://mon-devis-sans-oublis.beta.gouv.fr/)** 
 
 ## Prérequis
 
@@ -122,6 +124,14 @@ docker-compose down
 
 ## Développement
 
+### Démarrage express
+
+```bash
+# Installation et démarrage
+npm install
+npm run dev
+```
+
 ### Scripts disponibles
 
 | Script                    | Description                                |
@@ -129,12 +139,38 @@ docker-compose down
 | `npm run dev`             | Démarre le serveur de développement        |
 | `npm run build`           | Construit l'application pour la production |
 | `npm run start`           | Démarre le serveur de production           |
+| `npm run typecheck`       | Vérifie les types TypeScript               |
+| `npm run ci`              | Lance typecheck + lint + tests             |
 | `npm run test`            | Lance les tests avec Jest                  |
 | `npm run test:watch`      | Lance les tests en mode watch              |
 | `npm run test:coverage`   | Lance les tests avec rapport de couverture |
 | `npm run storybook`       | Démarre Storybook                          |
 | `npm run build-storybook` | Construit Storybook pour la production     |
 | `npm run lint`            | Vérifie la qualité du code avec ESLint     |
+| `npm run format`          | Formate le code avec Prettier              |
+| `npm run format:check`    | Vérifie le formatage sans modifier         |
+
+### Vérification qualité
+
+```bash
+# Tout vérifier d'un coup
+npm run ci
+
+# Ou étape par étape
+npm run typecheck
+npm run lint
+npm run test
+```
+
+### Commandes utiles
+
+```bash
+# Formatter automatiquement le code
+npm run format
+
+# Développer les composants isolément
+npm run storybook
+```
 
 ## Storybook
 
@@ -176,18 +212,25 @@ npm run test:coverage
 
 ## Qualité du code
 
-### Linting
+### Vérifications automatiques
 
 ```bash
-# Vérifier la qualité du code
-npm run lint
+# Vérification complète (CI)
+npm run ci
+
+# Vérifications individuelles
+npm run typecheck  # Types TypeScript
+npm run lint       # Qualité du code
+npm run test       # Tests unitaires
+npm run format     # Formatage du code
 ```
 
 ### Configuration
 
+- **TypeScript** : Configuration dans `tsconfig.json`
 - **ESLint** : Configuration dans `.eslintrc.json`
 - **Prettier** : Configuration dans `.prettierrc`
-- **TypeScript** : Configuration dans `tsconfig.json`
+- **Jest** : Tests unitaires et coverage
 
 ## Déploiement
 
@@ -224,3 +267,59 @@ docker run -p 3000:3000 mon-devis-frontend
 | **[Zod](https://zod.dev/)**                                    | 3.x     | Validation de schémas TypeScript                      |
 | **[Sentry](https://sentry.io/)**                               | 9.x     | Monitoring d'erreurs en production                    |
 | **[Matomo](https://matomo.org/)**                              | -       | Analytics respectueux de la vie privée                |
+
+## Architecture
+
+### Structure des dossiers
+
+```
+src/
+├── actions/           # Server Actions (Next.js 15)
+│   ├── quote.actions.ts
+│   ├── feedback.actions.ts
+│   └── stats.actions.ts
+├── components/        # Composants React réutilisables
+├── lib/              # Utilitaires et configuration
+│   ├── server/       # Code côté serveur
+│   └── client/       # Code côté client
+├── page-sections/    # Sections spécifiques aux pages
+├── types/           # Types TypeScript
+└── wording/         # Textes et traductions
+```
+
+### API et données
+
+- **Server Actions** : Appels API sécurisés côté serveur
+- **API Backend** : Ruby on Rails avec PostgreSQL
+- **Validation** : Zod pour les schémas TypeScript
+
+## Troubleshooting
+
+### Erreurs courantes
+
+**Erreur de types TypeScript :**
+```bash
+npm run typecheck
+```
+
+**Erreurs de lint :**
+```bash
+npm run lint
+npm run format
+```
+
+**Tests qui échouent :**
+```bash
+npm run test:watch
+```
+
+**Variables d'environnement manquantes :**
+- Vérifiez que `.env.local` existe
+- Copiez `.env.example` si nécessaire
+
+### Support
+
+Pour les problèmes techniques, vérifiez :
+1. Node.js version 22.x installée
+2. Variables d'environnement configurées
+3. `npm install` exécuté

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "ci": "npm run typecheck && npm run lint && npm run test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "jest",

--- a/src/actions/errorDetails.actions.ts
+++ b/src/actions/errorDetails.actions.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { apiClient } from "@/lib/server/apiClient";
+import { revalidatePath } from "next/cache";
+
+// Suppression d'un détail d'erreur
+export async function deleteErrorDetail(
+  quoteCheckId: string,
+  errorDetailsId: string,
+  reason: string
+): Promise<boolean> {
+  try {
+    if (!quoteCheckId || !errorDetailsId) {
+      throw new Error("Quote check ID and error details ID are required");
+    }
+
+    await apiClient.delete(
+      `/api/v1/quote_checks/${quoteCheckId}/error_details/${errorDetailsId}?reason=${reason}`
+    );
+
+    revalidatePath(`/result/${quoteCheckId}`);
+    return true;
+  } catch (error) {
+    console.error("Error deleting error detail:", error);
+    throw error;
+  }
+}
+
+// Annulation de la suppression d'un détail d'erreur
+export async function undoDeleteErrorDetail(
+  quoteCheckId: string,
+  errorDetailsId: string
+): Promise<boolean> {
+  try {
+    if (!quoteCheckId || !errorDetailsId) {
+      throw new Error("Quote check ID and error details ID are required");
+    }
+
+    await apiClient.post(
+      `/api/v1/quote_checks/${quoteCheckId}/error_details/${errorDetailsId}`
+    );
+
+    revalidatePath(`/result/${quoteCheckId}`);
+    return true;
+  } catch (error) {
+    console.error("Error undoing delete error detail:", error);
+    throw error;
+  }
+}
+
+// Récupération des raisons de suppression des détails d'erreur
+export async function getDeleteErrorDetailReasons(): Promise<
+  { id: string; label: string }[]
+> {
+  try {
+    const responseData = await apiClient.get(
+      "/api/v1/quote_checks/error_detail_deletion_reasons"
+    );
+
+    if (!responseData.data) {
+      throw new Error("Invalid response format: 'data' field is missing.");
+    }
+
+    return Object.entries(responseData.data).map(([key, value]) => ({
+      id: key,
+      label: value as string,
+    }));
+  } catch (error) {
+    console.error("Error fetching delete error detail reasons:", error);
+    throw error;
+  }
+}
+
+// Mise à jour d'un détail d'erreur
+export async function updateErrorDetail(
+  quoteCheckId: string,
+  errorDetailsId: string,
+  comment: string | null
+): Promise<boolean> {
+  try {
+    if (!quoteCheckId || !errorDetailsId) {
+      throw new Error("Quote check ID and error details ID are required");
+    }
+
+    await apiClient.patch(
+      `/api/v1/quote_checks/${quoteCheckId}/error_details/${errorDetailsId}`,
+      { comment }
+    );
+
+    revalidatePath(`/result/${quoteCheckId}`);
+    return true;
+  } catch (error) {
+    console.error("Error updating error detail:", error);
+    throw error;
+  }
+}

--- a/src/actions/feedback.actions.ts
+++ b/src/actions/feedback.actions.ts
@@ -7,7 +7,7 @@ interface FeedbackResponse {
   id?: string;
   comment: string;
   created_at?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface GlobalFeedbackData {

--- a/src/actions/feedback.actions.ts
+++ b/src/actions/feedback.actions.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { apiClient } from "@/lib/server/apiClient";
+import { Rating } from "@/types";
+
+interface FeedbackResponse {
+  id?: string;
+  comment: string;
+  created_at?: string;
+  [key: string]: any;
+}
+
+interface GlobalFeedbackData {
+  comment: string;
+  email: string | null;
+  rating: Rating;
+}
+
+// Envoi d'un feedback pour une erreur spécifique
+export async function sendErrorFeedback(
+  comment: string | null,
+  errorDetailsId: string,
+  quoteCheckId: string
+): Promise<FeedbackResponse> {
+  try {
+    if (!comment || !errorDetailsId || !quoteCheckId) {
+      throw new Error(
+        "Comment, error details ID, and quote check ID are required"
+      );
+    }
+
+    return await apiClient.post(
+      `/api/v1/quote_checks/${quoteCheckId}/error_details/${errorDetailsId}/feedbacks`,
+      { comment }
+    );
+  } catch (error) {
+    console.error("Error sending feedback:", error);
+    throw error;
+  }
+}
+
+// Envoi d'un feedback global sur le devis
+export async function sendGlobalFeedback(
+  quoteCheckId: string,
+  feedback: GlobalFeedbackData
+): Promise<FeedbackResponse> {
+  try {
+    if (!quoteCheckId) {
+      throw new Error("Quote check ID is required");
+    }
+
+    return await apiClient.post(
+      `/api/v1/quote_checks/${quoteCheckId}/feedbacks`,
+      { ...feedback }
+    );
+  } catch (error) {
+    console.error("Error sending global feedback:", error);
+    throw error;
+  }
+}

--- a/src/actions/quote.actions.ts
+++ b/src/actions/quote.actions.ts
@@ -1,0 +1,139 @@
+"use server";
+
+import { apiClient } from "@/lib/server/apiClient";
+import { ErrorDetails, Profile } from "@/types";
+import { revalidatePath } from "next/cache";
+
+interface QuoteUpdateData {
+  status?: string;
+  metadata?: {
+    aides?: string[];
+    gestes?: string[];
+  };
+}
+
+interface QuoteResponse {
+  id: string;
+  status: string;
+  metadata: {
+    aides: string[];
+    gestes: string[];
+  };
+  error_details?: ErrorDetails[];
+}
+
+// Récupération d'un devis
+export async function getQuote(quoteCheckId: string): Promise<QuoteResponse> {
+  try {
+    if (!quoteCheckId) {
+      throw new Error("Quote check ID is required");
+    }
+
+    return await apiClient.get(`/api/v1/quote_checks/${quoteCheckId}`);
+  } catch (error) {
+    console.error("Error fetching quote:", error);
+    throw error;
+  }
+}
+
+// Envoi d'un devis
+export async function uploadQuote(
+  file: File,
+  metadata: { aides: string[]; gestes: string[] },
+  profile: Profile
+): Promise<QuoteResponse> {
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("profile", profile);
+    formData.append("renovation_type", "geste");
+    formData.append("metadata", JSON.stringify(metadata));
+
+    const result = await apiClient.post("/api/v1/quote_checks", formData);
+
+    if (!result.id) {
+      throw new Error("The API didn't return an ID.");
+    }
+
+    return result;
+  } catch (error) {
+    console.error("Error uploading quote:", error);
+    throw error;
+  }
+}
+
+// Mise à jour d'un devis
+export async function updateQuote(
+  quoteCheckId: string,
+  updatedData: QuoteUpdateData
+): Promise<QuoteResponse> {
+  try {
+    if (!quoteCheckId) {
+      throw new Error("Quote check ID is required");
+    }
+
+    const result = await apiClient.patch(
+      `/api/v1/quote_checks/${quoteCheckId}`,
+      updatedData
+    );
+    revalidatePath(`/result/${quoteCheckId}`);
+    return result;
+  } catch (error) {
+    console.error("Error updating quote:", error);
+    throw error;
+  }
+}
+
+// Mise à jour du commentaire d'un devis
+export async function updateQuoteComment(
+  quoteCheckId: string,
+  comment: string | null
+): Promise<any | null> {
+  try {
+    if (!quoteCheckId) {
+      throw new Error("Quote check ID is required");
+    }
+
+    const result = await apiClient.patch(
+      `/api/v1/quote_checks/${quoteCheckId}`,
+      { comment }
+    );
+
+    revalidatePath(`/result/${quoteCheckId}`);
+
+    return result || null;
+  } catch (error) {
+    console.error("Error updating quote comment:", error);
+    throw error;
+  }
+}
+
+// Ajout d'un commentaire
+export async function addQuoteComment(
+  quoteCheckId: string,
+  comment: string
+): Promise<QuoteResponse> {
+  if (!comment.trim()) {
+    throw new Error("Comment cannot be empty");
+  }
+
+  await updateQuoteComment(quoteCheckId, comment);
+  return getQuote(quoteCheckId);
+}
+
+// Suppression d'un commentaire
+export async function removeQuoteComment(
+  quoteCheckId: string
+): Promise<any | null> {
+  return updateQuoteComment(quoteCheckId, null);
+}
+
+// Récupération des métadonnées des devis
+export async function getQuoteMetadata(): Promise<any> {
+  try {
+    return await apiClient.get("/api/v1/quote_checks/metadata");
+  } catch (error) {
+    console.error("Error fetching metadata:", error);
+    throw error;
+  }
+}

--- a/src/actions/quote.actions.ts
+++ b/src/actions/quote.actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { apiClient } from "@/lib/server/apiClient";
-import { ErrorDetails, Profile } from "@/types";
+import { Profile } from "@/types";
 import { revalidatePath } from "next/cache";
 
 interface QuoteUpdateData {

--- a/src/actions/quote.actions.ts
+++ b/src/actions/quote.actions.ts
@@ -12,18 +12,10 @@ interface QuoteUpdateData {
   };
 }
 
-interface QuoteResponse {
-  id: string;
-  status: string;
-  metadata: {
-    aides: string[];
-    gestes: string[];
-  };
-  error_details?: ErrorDetails[];
-}
+// Suppression du type restrictif QuoteResponse
 
-// Récupération d'un devis
-export async function getQuote(quoteCheckId: string): Promise<QuoteResponse> {
+// Récupération d'un devis - SANS typage restrictif
+export async function getQuote(quoteCheckId: string) {
   try {
     if (!quoteCheckId) {
       throw new Error("Quote check ID is required");
@@ -36,12 +28,12 @@ export async function getQuote(quoteCheckId: string): Promise<QuoteResponse> {
   }
 }
 
-// Envoi d'un devis
+// Envoi d'un devis - SANS typage restrictif
 export async function uploadQuote(
   file: File,
   metadata: { aides: string[]; gestes: string[] },
   profile: Profile
-): Promise<QuoteResponse> {
+) {
   try {
     const formData = new FormData();
     formData.append("file", file);
@@ -62,11 +54,11 @@ export async function uploadQuote(
   }
 }
 
-// Mise à jour d'un devis
+// Mise à jour d'un devis - SANS typage restrictif
 export async function updateQuote(
   quoteCheckId: string,
   updatedData: QuoteUpdateData
-): Promise<QuoteResponse> {
+) {
   try {
     if (!quoteCheckId) {
       throw new Error("Quote check ID is required");
@@ -88,7 +80,7 @@ export async function updateQuote(
 export async function updateQuoteComment(
   quoteCheckId: string,
   comment: string | null
-): Promise<any | null> {
+) {
   try {
     if (!quoteCheckId) {
       throw new Error("Quote check ID is required");
@@ -109,10 +101,7 @@ export async function updateQuoteComment(
 }
 
 // Ajout d'un commentaire
-export async function addQuoteComment(
-  quoteCheckId: string,
-  comment: string
-): Promise<QuoteResponse> {
+export async function addQuoteComment(quoteCheckId: string, comment: string) {
   if (!comment.trim()) {
     throw new Error("Comment cannot be empty");
   }
@@ -122,14 +111,12 @@ export async function addQuoteComment(
 }
 
 // Suppression d'un commentaire
-export async function removeQuoteComment(
-  quoteCheckId: string
-): Promise<any | null> {
+export async function removeQuoteComment(quoteCheckId: string) {
   return updateQuoteComment(quoteCheckId, null);
 }
 
 // Récupération des métadonnées des devis
-export async function getQuoteMetadata(): Promise<any> {
+export async function getQuoteMetadata() {
   try {
     return await apiClient.get("/api/v1/quote_checks/metadata");
   } catch (error) {

--- a/src/actions/stats.actions.ts
+++ b/src/actions/stats.actions.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { apiClient } from "@/lib/server/apiClient";
+
+export async function getStats() {
+  try {
+    return await apiClient.get("/api/v1/stats");
+  } catch (error) {
+    console.error("Error fetching stats:", error);
+    throw error;
+  }
+}

--- a/src/app/[profile]/televersement/[quoteCheckId]/modifier/page.tsx
+++ b/src/app/[profile]/televersement/[quoteCheckId]/modifier/page.tsx
@@ -1,4 +1,4 @@
-import { quoteService } from "@/lib/api";
+import { quoteService } from "@/lib/client/apiWrapper";
 import { EditClient } from "@/page-sections";
 
 type DeleteErrorReason = {

--- a/src/app/[profile]/televersement/[quoteCheckId]/page.tsx
+++ b/src/app/[profile]/televersement/[quoteCheckId]/page.tsx
@@ -1,5 +1,5 @@
 import { Notice } from "@/components";
-import { quoteService } from "@/lib/api";
+import { quoteService } from "@/lib/client/apiWrapper";
 import { ResultClient } from "@/page-sections";
 import wording from "@/wording";
 

--- a/src/app/[profile]/televersement/page.tsx
+++ b/src/app/[profile]/televersement/page.tsx
@@ -1,5 +1,5 @@
 import { Notice } from "@/components";
-import { quoteService } from "@/lib/api";
+import { quoteService } from "@/lib/client/apiWrapper";
 import { UploadClient } from "@/page-sections";
 import { Metadata } from "@/types";
 import wording from "@/wording";

--- a/src/app/statistiques/page.tsx
+++ b/src/app/statistiques/page.tsx
@@ -1,5 +1,5 @@
 import { Notice } from "@/components";
-import { statService } from "@/lib/api";
+import { statService } from "@/lib/client/apiWrapper";
 import wording from "@/wording";
 
 export default async function Statistics() {

--- a/src/components/index.test.ts
+++ b/src/components/index.test.ts
@@ -106,6 +106,5 @@ describe("Components exports", () => {
     expect(Components.LinkSize).toBeDefined();
     expect(Components.LinkVariant).toBeDefined();
     expect(Components.ModalPosition).toBeDefined();
-    expect(Components.QuoteStatusType).toBeDefined();
   });
 });

--- a/src/lib/api.old.ts
+++ b/src/lib/api.old.ts
@@ -1,4 +1,5 @@
 // src/lib/api.ts
+// TODO : Remove this file when the API Server Action migration is complete
 import { ErrorDetails, Profile, Rating } from "@/types";
 import { isClient, isServer } from "./utils/env.utils";
 import { getServerEnv, getSharedEnv } from "./config/env.config";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,7 +67,8 @@ function getApiUrl(): string {
 }
 
 // Quote Service
-export const quoteService = {
+// TODO : Remove this service when the API Server Action migration is complete
+export const quoteServiceToRemove = {
   // Quote Management
   async uploadQuote(
     file: File,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -471,7 +471,8 @@ export const quoteService = {
 };
 
 // Statistics Service
-export const statService = {
+// TODO : Remove this service when the API Server Action migration is complete
+export const statServiceToRemove = {
   async getStats() {
     try {
       const response = await fetch(`${getApiUrl()}/api/v1/stats`, {

--- a/src/lib/client/apiWrapper.ts
+++ b/src/lib/client/apiWrapper.ts
@@ -4,13 +4,17 @@ import {
   updateQuote,
   updateQuoteComment,
   getQuoteMetadata,
+  addQuoteComment,
+  removeQuoteComment,
 } from "@/actions/quote.actions";
 
 import {
   sendErrorFeedback,
   sendGlobalFeedback,
 } from "@/actions/feedback.actions";
+
 import { getStats } from "@/actions/stats.actions";
+
 import {
   deleteErrorDetail,
   getDeleteErrorDetailReasons,
@@ -25,6 +29,8 @@ export const quoteService = {
   updateQuote,
   updateQuoteComment,
   getQuoteMetadata,
+  addQuoteComment,
+  removeQuoteComment,
   deleteErrorDetail,
   undoDeleteErrorDetail,
   getDeleteErrorDetailReasons,

--- a/src/lib/client/apiWrapper.ts
+++ b/src/lib/client/apiWrapper.ts
@@ -1,0 +1,41 @@
+import {
+  getQuote,
+  uploadQuote,
+  updateQuote,
+  updateQuoteComment,
+  getQuoteMetadata,
+} from "@/actions/quote.actions";
+
+import {
+  sendErrorFeedback,
+  sendGlobalFeedback,
+} from "@/actions/feedback.actions";
+import { getStats } from "@/actions/stats.actions";
+import {
+  deleteErrorDetail,
+  getDeleteErrorDetailReasons,
+  undoDeleteErrorDetail,
+  updateErrorDetail,
+} from "@/actions/errorDetails.actions";
+
+// Wrapper pour maintenir la compatibilité avec l'ancien code
+export const quoteService = {
+  getQuote,
+  uploadQuote,
+  updateQuote,
+  updateQuoteComment,
+  getQuoteMetadata,
+  deleteErrorDetail,
+  undoDeleteErrorDetail,
+  getDeleteErrorDetailReasons,
+  updateErrorDetail,
+  addErrorComment: updateErrorDetail,
+  removeErrorDetailComment: (quoteCheckId: string, errorDetailsId: string) =>
+    updateErrorDetail(quoteCheckId, errorDetailsId, null),
+  sendErrorFeedback,
+  sendGlobalFeedback,
+};
+
+export const statService = {
+  getStats,
+};

--- a/src/lib/server/apiClient.ts
+++ b/src/lib/server/apiClient.ts
@@ -1,0 +1,80 @@
+import { getServerEnv, getSharedEnv } from "../config/env.config";
+
+function getHeaders(): HeadersInit {
+  const serverEnv = getServerEnv();
+  return {
+    accept: "application/json",
+    Authorization: `Bearer ${serverEnv.NEXT_PRIVATE_API_AUTH_TOKEN}`,
+  };
+}
+
+function getApiUrl(): string {
+  const sharedEnv = getSharedEnv();
+  return sharedEnv.NEXT_PUBLIC_API_URL;
+}
+
+export const apiClient = {
+  async get(endpoint: string) {
+    const response = await fetch(`${getApiUrl()}${endpoint}`, {
+      headers: getHeaders(),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  },
+
+  async post(endpoint: string, data?: any) {
+    const response = await fetch(`${getApiUrl()}${endpoint}`, {
+      method: "POST",
+      headers: {
+        ...getHeaders(),
+        ...(!(data instanceof FormData) && {
+          "Content-Type": "application/json",
+        }),
+      },
+      body: data instanceof FormData ? data : JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+    }
+
+    if (response.status === 204) return null;
+    return response.json();
+  },
+
+  async patch(endpoint: string, data: any) {
+    const response = await fetch(`${getApiUrl()}${endpoint}`, {
+      method: "PATCH",
+      headers: {
+        ...getHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+    }
+
+    if (response.status === 204) return null;
+    return response.json();
+  },
+
+  async delete(endpoint: string) {
+    const response = await fetch(`${getApiUrl()}${endpoint}`, {
+      method: "DELETE",
+      headers: getHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+    }
+
+    return response;
+  },
+};

--- a/src/lib/server/apiClient.ts
+++ b/src/lib/server/apiClient.ts
@@ -27,7 +27,7 @@ export const apiClient = {
     return response.json();
   },
 
-  async post(endpoint: string, data?: any) {
+  async post(endpoint: string, data?: unknown) {
     const response = await fetch(`${getApiUrl()}${endpoint}`, {
       method: "POST",
       headers: {
@@ -47,7 +47,7 @@ export const apiClient = {
     return response.json();
   },
 
-  async patch(endpoint: string, data: any) {
+  async patch(endpoint: string, data: unknown) {
     const response = await fetch(`${getApiUrl()}${endpoint}`, {
       method: "PATCH",
       headers: {

--- a/src/lib/server/apiClient.ts
+++ b/src/lib/server/apiClient.ts
@@ -44,7 +44,15 @@ export const apiClient = {
     }
 
     if (response.status === 204) return null;
-    return response.json();
+
+    // Vérifier si il y a du contenu avant de parser
+    const contentLength = response.headers.get("content-length");
+    if (contentLength === "0") return null;
+
+    const text = await response.text();
+    if (!text.trim()) return null;
+
+    return JSON.parse(text);
   },
 
   async patch(endpoint: string, data: unknown) {
@@ -62,7 +70,15 @@ export const apiClient = {
     }
 
     if (response.status === 204) return null;
-    return response.json();
+
+    // Même logique que POST - vérifier le contenu
+    const contentLength = response.headers.get("content-length");
+    if (contentLength === "0") return null;
+
+    const text = await response.text();
+    if (!text.trim()) return null;
+
+    return JSON.parse(text);
   },
 
   async delete(endpoint: string) {

--- a/src/page-sections/edit/EditClient.tsx
+++ b/src/page-sections/edit/EditClient.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from "react";
 
 import { LoadingDots } from "@/components";
-import { quoteService } from "@/lib/api";
 import { ResultClient } from "@/page-sections";
 import { QuoteChecksId } from "@/types";
 import wording from "@/wording";
+import { quoteService } from "@/lib/client/apiWrapper";
 
 export default function EditClient({
   deleteErrorReasons,

--- a/src/page-sections/result/ResultClient.tsx
+++ b/src/page-sections/result/ResultClient.tsx
@@ -14,10 +14,10 @@ import {
   Toast,
 } from "@/components";
 import { useConseillerRoutes, useScrollPosition } from "@/hooks";
-import { quoteService } from "@/lib/api";
 import { Category, ErrorDetails, QuoteChecksId, Rating, Status } from "@/types";
 import { formatDateToFrench } from "@/utils";
 import wording from "@/wording";
+import { quoteService } from "@/lib/client/apiWrapper";
 
 interface ResultClientProps {
   currentDevis: QuoteChecksId | null;

--- a/src/page-sections/upload/UploadClient.tsx
+++ b/src/page-sections/upload/UploadClient.tsx
@@ -12,9 +12,9 @@ import {
   Notice,
   Upload,
 } from "@/components";
-import { quoteService } from "@/lib/api";
 import { Metadata, Profile } from "@/types";
 import wording from "@/wording";
+import { quoteService } from "@/lib/client/apiWrapper";
 
 export const FILE_ERROR = "file_error";
 


### PR DESCRIPTION
---
Dépends de : https://github.com/MTES-MCT/mon-devis-sans-oublis-frontend/pull/138
---

Refactorisation des appels API pour suivre la bonne pratique d'utiliser les **Server Actions** de NextJS (coté server only + safe)

👉🏼 Création d'un apiClient.ts centralisant la logique d'appel API
👉🏼 Découpage des appels API en **Server Actions** selon la logique
👉🏼 Création d'un apiWrapper pour limiter au maximum les modifications de code coté clients et composants existants
👉🏼 Bonus ajout d'une commande CI dans le package.json & update du ReadMe

En sortie de cette PR le Front devrait utiliser les **Server Actions** pour tous les appels API


---
Note : 
Une fois le déploiement fait et validé / migré il faudra supprimer l'ancien fichier api.old.ts qui n'est plus utile.

---
Note 2 : 
Il y a encore des tests unitaires qui ne passent pas, il feront l'objet d'une future PR