### PR TITLE
feat: increase body limit for server actions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,11 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@gouvfr/dsfr"],
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "50mb",
+    },
+  },
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
En utilisant les server actions il faut définir la limite du body (par défaut 1mb)

Erreur rencontrée en prod : https://sentry.incubateur.net/organizations/betagouv/issues/176659/?alert_rule_id=180&alert_timestamp=1748865682632&alert_type=email&environment=production&notification_uuid=394357c9-b87f-4152-8a92-3ee01abbaa81&project=206&referrer=alert_email

Je propose une grosse limite pour l'instant (à ajuster)