### PR TITLE
feat: matomo heatmaps

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import wording from "@/wording";
 import { marianne, spectral } from "../styles/fonts";
 import "../styles/globals.css";
 import CrispWrapper from "@/components/Crisp/Crisp";
+import { useMatomo } from "@/hooks/useMatomo";
+import { useEffect } from "react";
 
 // DSFR initialization
 initDsfr();
@@ -22,6 +24,12 @@ export default function RootLayout({
 }>) {
   const footerData: FooterProps = wording.layout.footer;
   const headerData: HeaderProps = wording.layout.header;
+  const { enableHeatmaps } = useMatomo();
+
+  // Activation heatMaps Matomo au chargement
+  useEffect(() => {
+    enableHeatmaps();
+  }, [enableHeatmaps]);
 
   return (
     <html

--- a/src/hooks/useMatomo.ts
+++ b/src/hooks/useMatomo.ts
@@ -5,6 +5,7 @@ import { type MatomoEvent } from "@/lib/constants/matomoEvents";
 interface UseMatomo {
   trackEvent: (eventName: MatomoEvent, additionalData?: string) => void;
   trackPageView: (customUrl?: string) => void;
+  enableHeatmaps: () => void;
   isEnabled: boolean;
 }
 
@@ -42,9 +43,23 @@ export function useMatomo(): UseMatomo {
     }
   };
 
+  const enableHeatmaps = () => {
+    if (!isEnabled) {
+      console.log("[Matomo Debug] Heatmaps enabled");
+      return;
+    }
+
+    try {
+      push(["HeatmapSessionRecording::enable"]);
+    } catch (error) {
+      console.warn("Erreur Matomo heatmaps:", error);
+    }
+  };
+
   return {
     trackEvent,
     trackPageView,
+    enableHeatmaps,
     isEnabled,
   };
 }


### PR DESCRIPTION
Activation des heatMaps matomo pour gestion des cartes de chaleurs / funnels 

Cf. dans matomo

![image](https://github.com/user-attachments/assets/2178d74f-c21e-4efb-9221-f8386631c461)
