### PR TITLE
fix: matomo heatMaps in matomo component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,6 @@ import wording from "@/wording";
 import { marianne, spectral } from "../styles/fonts";
 import "../styles/globals.css";
 import CrispWrapper from "@/components/Crisp/Crisp";
-import { useMatomo } from "@/hooks/useMatomo";
-import { useEffect } from "react";
 
 // DSFR initialization
 initDsfr();
@@ -24,12 +22,6 @@ export default function RootLayout({
 }>) {
   const footerData: FooterProps = wording.layout.footer;
   const headerData: HeaderProps = wording.layout.header;
-  const { enableHeatmaps } = useMatomo();
-
-  // Activation heatMaps Matomo au chargement
-  useEffect(() => {
-    enableHeatmaps();
-  }, [enableHeatmaps]);
 
   return (
     <html

--- a/src/components/Matomo/Matomo.tsx
+++ b/src/components/Matomo/Matomo.tsx
@@ -4,9 +4,11 @@ import { Suspense, useEffect, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { init, push } from "@socialgouv/matomo-next";
 import { getClientEnv, isProduction, isStaging } from "@/lib/config/env.config";
+import { useMatomo } from "@/hooks/useMatomo";
 
 const MatomoContent = () => {
   const [initialised, setInitialised] = useState<boolean>(false);
+  const { enableHeatmaps } = useMatomo();
 
   useEffect(() => {
     const clientEnv = getClientEnv();
@@ -24,6 +26,13 @@ const MatomoContent = () => {
       setInitialised(true);
     }
   }, [initialised]);
+
+  // Activation des heatmaps quand Matomo est initialisé
+  useEffect(() => {
+    if (initialised) {
+      enableHeatmaps();
+    }
+  }, [initialised, enableHeatmaps]);
 
   const pathname = usePathname();
   const searchParams = useSearchParams();


### PR DESCRIPTION
Déplacement de l'utilisation des heatmaps directement dans le composant Matomo (au lieu de le mettre en layout car nécessité de le mettre dans un composant client)