### PR TITLE
feat: disabling reno ampleur button before upload

### DIFF
--- a/src/app/[profile]/televersement/renovation-ampleur/page.tsx
+++ b/src/app/[profile]/televersement/renovation-ampleur/page.tsx
@@ -14,6 +14,7 @@ export default function UploadRenovationAmpleurPage() {
   const [fileError, setFileError] = useState<string | null>(null);
   const [selectedAides, setSelectedAides] = useState<string[]>([]);
   const [selectedGestes, setSelectedGestes] = useState<string[]>([]);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const params = useParams();
   const router = useRouter();
@@ -26,7 +27,10 @@ export default function UploadRenovationAmpleurPage() {
   }, []);
 
   const handleNext = async () => {
-    if (uploadedFiles.length === 0) return;
+    if (uploadedFiles.length === 0 || isProcessing) return;
+
+    setIsProcessing(true);
+    setFileError(null);
 
     try {
       // Création du dossier
@@ -49,10 +53,12 @@ export default function UploadRenovationAmpleurPage() {
       setFileError(
         "Une erreur est survenue lors du téléversement. Veuillez réessayer."
       );
+      setIsProcessing(false); 
     }
   };
 
   const handlePrevious = () => {
+    if (isProcessing) return;
     router.back();
   };
 
@@ -112,18 +118,23 @@ export default function UploadRenovationAmpleurPage() {
                 <button
                   className="fr-btn fr-btn--secondary"
                   onClick={handlePrevious}
+                  disabled={isProcessing}
                 >
                   Précédent
                 </button>
 
                 <button
                   className={`fr-btn ${
-                    uploadedFiles.length === 0 ? "fr-btn--secondary" : ""
+                    uploadedFiles.length === 0 || isProcessing
+                      ? "fr-btn--secondary"
+                      : ""
                   }`}
-                  disabled={uploadedFiles.length === 0}
+                  disabled={uploadedFiles.length === 0 || isProcessing}
                   onClick={handleNext}
                 >
-                  Vérifiez les devis
+                  {isProcessing
+                    ? "Traitement en cours..."
+                    : "Vérifiez les devis"}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
Désactivation du bouton "Vérifiez les devis" lors de l'upload en réno d'ampleur pour éviter les appels multiples.

<img width="1630" height="1394" alt="image" src="https://github.com/user-attachments/assets/0248e5cc-1708-4f9b-a9c8-77679ce45cee" />
